### PR TITLE
Discard master/slave vocabulary

### DIFF
--- a/alembic/versions/20171124_1424_f7dcd0d26e39_046_ownership_overhaul.py
+++ b/alembic/versions/20171124_1424_f7dcd0d26e39_046_ownership_overhaul.py
@@ -83,7 +83,7 @@ class DbUserToOwner(Base):
 
 class DbKeychestAgent(Base):
     """
-    Keychest agent record - identifies particular keychest slave instance
+    Keychest agent record - identifies particular keychest subordinate instance
     """
     __tablename__ = 'keychest_agent'
     id = Column(BigInteger, primary_key=True)

--- a/keychest/config.py
+++ b/keychest/config.py
@@ -46,8 +46,8 @@ class Config(object):
         def_cfg['keychest_max_servers'] = 1000
         def_cfg['enable_rest_api'] = False
         def_cfg['agent_mode'] = False
-        def_cfg['master_endpoint'] = None
-        def_cfg['master_apikey'] = None
+        def_cfg['main_endpoint'] = None
+        def_cfg['main_apikey'] = None
 
         root = collections.OrderedDict()
         root['config'] = def_cfg
@@ -164,23 +164,23 @@ class Config(object):
     def agent_mode(self, val):
         self.set_config('agent_mode', val)
 
-    # master node endpoint
+    # main node endpoint
     @property
-    def master_endpoint(self):
-        return self.get_config('master_endpoint', None)
+    def main_endpoint(self):
+        return self.get_config('main_endpoint', None)
 
-    @master_endpoint.setter
-    def master_endpoint(self, val):
-        self.set_config('master_endpoint', val)
+    @main_endpoint.setter
+    def main_endpoint(self, val):
+        self.set_config('main_endpoint', val)
 
-    # API key for master
+    # API key for main
     @property
-    def master_apikey(self):
-        return self.get_config('master_apikey', None)
+    def main_apikey(self):
+        return self.get_config('main_apikey', None)
 
-    @master_apikey.setter
-    def master_apikey(self, val):
-        self.set_config('master_apikey', val)
+    @main_apikey.setter
+    def main_apikey(self, val):
+        self.set_config('main_apikey', val)
 
     # Workers - key test scanner
     @property

--- a/keychest/consts.py
+++ b/keychest/consts.py
@@ -84,7 +84,7 @@ class JobType(object):
 class DbLastScanCacheType(object):
     LOCAL_SCAN = 0  # normal local scans
     AGENT_SCAN = 10  # caching latest results seen from agent - remote numbering
-    MASTER_SCAN = 11  # caching last results seen from master
+    MASTER_SCAN = 11  # caching last results seen from main
 
 
 class IpType(object):

--- a/keychest/dbutil.py
+++ b/keychest/dbutil.py
@@ -673,7 +673,7 @@ class DbLastScanCache(Base):
     Last scan cache - in order to avoid complicated sub-queries.
 
     Mapping table optimizes searching for the most recent scan for the given object.
-    Caches the recent scans, helps to keep data in sync in the master - agent environment.
+    Caches the recent scans, helps to keep data in sync in the main - agent environment.
     """
     __tablename__ = 'last_scan_cache'
     __table_args__ = (UniqueConstraint('cache_type', 'obj_id', 'scan_type', 'scan_sub_type', 'aux_key',
@@ -962,7 +962,7 @@ class DbOrganizationGroup(Base):
 
 class DbKeychestAgent(Base):
     """
-    Keychest agent record - identifies particular keychest slave instance
+    Keychest agent record - identifies particular keychest subordinate instance
     """
     __tablename__ = 'keychest_agent'
     id = Column(BigInteger, primary_key=True)

--- a/keychest/keys_tools.py
+++ b/keychest/keys_tools.py
@@ -92,16 +92,16 @@ def process_pgp(data):
     pgp_key_data = AsciiData(data)
     packets = list(pgp_key_data.packets())
 
-    master_fprint = None
-    master_key_id = None
+    main_fprint = None
+    main_key_id = None
     identities = []
     pubkeys = []
     sign_key_ids = []
     sig_cnt = 0
     for idx, packet in enumerate(packets):
         if isinstance(packet, PublicKeyPacket):
-            master_fprint = packet.fingerprint
-            master_key_id = detect.format_pgp_key(packet.key_id)
+            main_fprint = packet.fingerprint
+            main_key_id = detect.format_pgp_key(packet.key_id)
             pubkeys.append(packet)
         elif isinstance(packet, PublicSubkeyPacket):
             pubkeys.append(packet)
@@ -124,8 +124,8 @@ def process_pgp(data):
             identity = '%s <%s>' % (packet.user_name, packet.user_email)
 
     js_base['type'] = 'pgp'
-    js_base['master_fprint'] = master_fprint
-    js_base['master_key_id'] = master_key_id
+    js_base['main_fprint'] = main_fprint
+    js_base['main_key_id'] = main_key_id
     js_base['identities'] = ids_arr
     js_base['signatures_count'] = sig_cnt
     js_base['packets_count'] = len(packets)

--- a/keychest/redis_helper.py
+++ b/keychest/redis_helper.py
@@ -253,7 +253,7 @@ def default_envelope(listener_name='App\\Listeners\\ScanJobListener',
 
 def scan_job_progress(data=None):
     """
-    Returns event wrapped in the master event envelope
+    Returns event wrapped in the main event envelope
     :param data: 
     :return: 
     """
@@ -266,7 +266,7 @@ def scan_job_progress(data=None):
 
 def tester_job_progress(data=None):
     """
-    Returns event wrapped in the master event envelope
+    Returns event wrapped in the main event envelope
 
     :param data:
     :return:

--- a/keychest/server.py
+++ b/keychest/server.py
@@ -235,8 +235,8 @@ class Server(object):
             raise ValueError('Invalid start arguments')
 
         self.agent_mode = self.config.agent_mode
-        if self.agent_mode and util.is_empty(self.config.master_endpoint):
-            raise ValueError('Master endpoint is required in agent mode')
+        if self.agent_mode and util.is_empty(self.config.main_endpoint):
+            raise ValueError('Main endpoint is required in agent mode')
 
     def init_log(self):
         """
@@ -4065,13 +4065,13 @@ class Server(object):
         # executes all modules kick off
         self.run_modules()
 
-        # REST server needed only for master mode for now (may be changed in future).
+        # REST server needed only for main mode for now (may be changed in future).
         # Init agent mode if needed.
         if self.agent_mode:
             logger.info(' ==== Keychest scanner running in the Agent mode ==== ')
             self.mod_agent.init_agent()
         else:
-            logger.info(' ==== Keychest scanner running in the Master mode ==== ')
+            logger.info(' ==== Keychest scanner running in the Main mode ==== ')
             self.init_api()
 
         # Daemon vs. run mode.

--- a/keychest/server_agent.py
+++ b/keychest/server_agent.py
@@ -94,7 +94,7 @@ class ServerAgent(ServerModule):
         if not self.agent_mode():
             return  # just safety check not to do mess in the database
 
-        logger.debug('Master endpoint: %s' % self.config.master_endpoint)
+        logger.debug('Main endpoint: %s' % self.config.main_endpoint)
 
         s = None
         try:
@@ -150,7 +150,7 @@ class ServerAgent(ServerModule):
             user = DbUser()
             user.id = 1
             user.name = 'PLACEHOLDER'
-            user.email = 'local@master.net'
+            user.email = 'local@main.net'
             user.primary_owner_id = owner.id
             user.created_at = user.updated_at = salch.func.now()
             s.add(user)
@@ -167,7 +167,7 @@ class ServerAgent(ServerModule):
 
     def _agent_request_get(self, url, **kwds):
         """
-        GET request to the master
+        GET request to the main
         :param url:
         :param kwds:
         :return:
@@ -176,7 +176,7 @@ class ServerAgent(ServerModule):
 
     def _agent_request_post(self, url, **kwds):
         """
-        POST request to the master
+        POST request to the main
         :param url:
         :param kwds:
         :return:
@@ -192,7 +192,7 @@ class ServerAgent(ServerModule):
         :return:
         """
         headers = kwds.get('headers', {})
-        headers['X-Auth-API'] = self.config.master_apikey
+        headers['X-Auth-API'] = self.config.main_apikey
 
         kwds['headers'] = headers
         kwds.setdefault('timeout', 10)
@@ -200,18 +200,18 @@ class ServerAgent(ServerModule):
         attempts = kwds.get('attempts', 3)
         for attempt in range(attempts):
             try:
-                r = requests.request(method=method, url=self.config.master_endpoint + url, **kwds)
+                r = requests.request(method=method, url=self.config.main_endpoint + url, **kwds)
                 r.raise_for_status()
                 return r
 
             except Exception as e:
-                logger.info('Exception in master request %s: %s' % (url, e))
+                logger.info('Exception in main request %s: %s' % (url, e))
                 if attempt + 1 >= attempts:
                     raise
 
     def agent_sync_hosts(self, s):
         """
-        Syncs hosts with the master by calling get hosts method and syncing
+        Syncs hosts with the main by calling get hosts method and syncing
         :param s:
         :return:
         """
@@ -222,7 +222,7 @@ class ServerAgent(ServerModule):
 
     def agent_merge_hosts(self, s, targets):
         """
-        Merges loaded hosts from the master
+        Merges loaded hosts from the main
         :return:
         """
         allowed_ids = []
@@ -306,7 +306,7 @@ class ServerAgent(ServerModule):
 
     def agent_sync_hosts_main(self):
         """
-        Main thread for hosts sync with the master
+        Main thread for hosts sync with the main
         :return:
         """
         logger.info('Agent host sync thread started %s %s %s' % (os.getpid(), os.getppid(), threading.current_thread()))
@@ -341,7 +341,7 @@ class ServerAgent(ServerModule):
 
     def agent_publisher_main(self):
         """
-        Main thread publishing results to the master
+        Main thread publishing results to the main
         :return:
         """
         logger.info('Agent publish thread started %s %s %s' % (os.getpid(), os.getppid(), threading.current_thread()))
@@ -379,7 +379,7 @@ class ServerAgent(ServerModule):
         Main publish entry point
         :return:
         """
-        # TODO: fetch all last scans from the master, load all scans greater than those provided and publish
+        # TODO: fetch all last scans from the main, load all scans greater than those provided and publish
         # TODO    missing first. Then process queue with new scans - ignore those already being sent.
 
         # Queue processing
@@ -444,7 +444,7 @@ class ServerAgent(ServerModule):
 
     def agent_dictize_scan(self, s, obj):
         """
-        Converts a scan to a dict serializable over the channel to the master
+        Converts a scan to a dict serializable over the channel to the main
         :param s:
         :param obj:
         :return:

--- a/keychest/server_api.py
+++ b/keychest/server_api.py
@@ -454,7 +454,7 @@ class RestAPI(object):
         Client then should ask for last scan IDs and push all missing ones.
 
         To make it simple for now we skip this check by client passing data.json['sorry'] = 1.
-        This also has a legitimate use when agent just does not have last scan as master desires.
+        This also has a legitimate use when agent just does not have last scan as main desires.
 
         One request should contain scans only for one hosts so rejection affects only the single host.
 

--- a/keychest/server_key_tester.py
+++ b/keychest/server_key_tester.py
@@ -436,7 +436,7 @@ class KeyTester(ServerModule):
             js = keys_tools.process_pgp(data)
 
             idset = set()
-            for x in detect.drop_none([js['master_key_id']] + js['signature_keys']):
+            for x in detect.drop_none([js['main_key_id']] + js['signature_keys']):
                 idset.add(x)
 
             for key in list(idset)[:4]:

--- a/keychest/server_management.py
+++ b/keychest/server_management.py
@@ -995,7 +995,7 @@ class ManagementModule(ServerModule):
         # Attempt renewal now.
         # For now support only simple use cases. E.g., LetsEncrypt renewal.
         # LE Renewal: call Certbot, fetch new certificate from the cert store, deploy later.
-        # LE certbot should run on the agent. For now on the master directly.
+        # LE certbot should run on the agent. For now on the main directly.
         job.target = s.merge(job.target)
         pki_type = job.target.svc_ca.pki_type if job.target.svc_ca is not None else None
 
@@ -1136,7 +1136,7 @@ class ManagementModule(ServerModule):
         # Signalize event - new certificate
         self.events.on_renewed_certificate(leaf_cert, job, new_managed_cert)
 
-        # TODO: In the agent - signalize this event to the master, attach new certificate & privkey
+        # TODO: In the agent - signalize this event to the main, attach new certificate & privkey
         pass
 
         # Trigger tests - set last scan to null


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.